### PR TITLE
Remove legacy pip ,  compatible with Python>=3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Instead, this script is only restricted by a daily upload limit for a channel on
 
 ## Package Installation
 ```bash
-pip install --upgrade youtube-uploader-selenium
-# or
 pip3 install --upgrade youtube-uploader-selenium
 ```
 


### PR DESCRIPTION
The package distributed on `PyPI` is labelled as only compatible with Python >=3. Using `pip` implies Python 2.x. Might be good to remove this line to avoid confusion.