### PR TITLE
Update old xpaths, add thumbnail upload support, add tags support

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -3,8 +3,8 @@ from youtube_uploader_selenium import YouTubeUploader
 from typing import Optional
 
 
-def main(video_path: str, metadata_path: Optional[str] = None):
-    uploader = YouTubeUploader(video_path, metadata_path)
+def main(video_path: str, metadata_path: Optional[str] = None, thumbnail_path: Optional[str] = None):
+    uploader = YouTubeUploader(video_path, metadata_path, thumbnail_path)
     was_video_uploaded, video_id = uploader.upload()
     assert was_video_uploaded
 
@@ -14,6 +14,9 @@ if __name__ == "__main__":
     parser.add_argument("--video",
                         help='Path to the video file',
                         required=True)
+    parser.add_argument("-t",
+                        "--thumbnail",
+                        help='Path to the thumbnail image',)
     parser.add_argument("--meta", help='Path to the JSON file with metadata')
     args = parser.parse_args()
-    main(args.video, args.meta)
+    main(args.video, args.meta, args.thumbnail)

--- a/youtube_uploader_selenium/Constant.py
+++ b/youtube_uploader_selenium/Constant.py
@@ -6,14 +6,14 @@ class Constant:
     USER_WAITING_TIME = 1
     VIDEO_TITLE = 'title'
     VIDEO_DESCRIPTION = 'description'
-    DESCRIPTION_CONTAINER = '/html/body/ytcp-uploads-dialog/paper-dialog/div/ytcp-animatable[1]/' \
+    DESCRIPTION_CONTAINER = '/html/body/ytcp-uploads-dialog/tp-yt-paper-dialog/div/ytcp-animatable[1]/' \
                             'ytcp-uploads-details/div/ytcp-uploads-basics/ytcp-mention-textbox[2]'
-    MORE_OPTIONS_CONTAINER = '/html/body/ytcp-uploads-dialog/paper-dialog/div/ytcp-animatable[1]/' \
+    MORE_OPTIONS_CONTAINER = '/html/body/ytcp-uploads-dialog/tp-yt-paper-dialog/div/ytcp-animatable[1]/' \
                              'ytcp-uploads-details/div/div/ytcp-button/div'
     TEXTBOX = 'textbox'
     TEXT_INPUT = 'text-input'
     RADIO_LABEL = 'radioLabel'
-    STATUS_CONTAINER = '/html/body/ytcp-uploads-dialog/paper-dialog/div/ytcp-animatable[2]/' \
+    STATUS_CONTAINER = '/html/body/ytcp-uploads-dialog/tp-yt-paper-dialog/div/ytcp-animatable[2]/' \
                        'div/div[1]/ytcp-video-upload-progress/span'
     NOT_MADE_FOR_KIDS_LABEL = 'NOT_MADE_FOR_KIDS'
     NEXT_BUTTON = 'next-button'

--- a/youtube_uploader_selenium/Constant.py
+++ b/youtube_uploader_selenium/Constant.py
@@ -6,16 +6,18 @@ class Constant:
     USER_WAITING_TIME = 1
     VIDEO_TITLE = 'title'
     VIDEO_DESCRIPTION = 'description'
+    VIDEO_TAGS = 'tags'
     DESCRIPTION_CONTAINER = '/html/body/ytcp-uploads-dialog/tp-yt-paper-dialog/div/ytcp-animatable[1]/' \
                             'ytcp-uploads-details/div/ytcp-uploads-basics/ytcp-mention-textbox[2]'
-    MORE_OPTIONS_CONTAINER = '/html/body/ytcp-uploads-dialog/tp-yt-paper-dialog/div/ytcp-animatable[1]/' \
-                             'ytcp-uploads-details/div/div/ytcp-button/div'
     TEXTBOX = 'textbox'
     TEXT_INPUT = 'text-input'
     RADIO_LABEL = 'radioLabel'
     STATUS_CONTAINER = '/html/body/ytcp-uploads-dialog/tp-yt-paper-dialog/div/ytcp-animatable[2]/' \
                        'div/div[1]/ytcp-video-upload-progress/span'
     NOT_MADE_FOR_KIDS_LABEL = 'NOT_MADE_FOR_KIDS'
+    MORE_BUTTON = '/html/body/ytcp-uploads-dialog/tp-yt-paper-dialog/div/ytcp-animatable[1]/ytcp-uploads-details/div/div/ytcp-button'
+    TAGS_INPUT_CONTAINER = '/html/body/ytcp-uploads-dialog/tp-yt-paper-dialog/div/ytcp-animatable[1]/ytcp-uploads-details/div/ytcp-uploads-advanced/ytcp-form-input-container/div[1]/div[2]/ytcp-free-text-chip-bar/ytcp-chip-bar/div'
+    TAGS_INPUT = 'text-input'
     NEXT_BUTTON = 'next-button'
     PUBLIC_BUTTON = 'PUBLIC'
     VIDEO_URL_CONTAINER = "//span[@class='video-url-fadeable style-scope ytcp-video-info']"

--- a/youtube_uploader_selenium/Constant.py
+++ b/youtube_uploader_selenium/Constant.py
@@ -26,3 +26,4 @@ class Constant:
     VIDEO_NOT_FOUND_ERROR = 'Could not find video_id'
     DONE_BUTTON = 'done-button'
     INPUT_FILE_VIDEO = "//input[@type='file']"
+    INPUT_FILE_THUMBNAIL = "//input[@id='file-loader']"

--- a/youtube_uploader_selenium/__init__.py
+++ b/youtube_uploader_selenium/__init__.py
@@ -66,6 +66,16 @@ class YouTubeUploader:
             time.sleep(Constant.USER_WAITING_TIME)
             self.browser.save_cookies()
 
+    def __write_in_field(self, field, string, select_all=False):
+        field.click()
+        time.sleep(Constant.USER_WAITING_TIME)
+        field.clear()
+        time.sleep(Constant.USER_WAITING_TIME)
+        if select_all:
+            field.send_keys(Keys.COMMAND + 'a')
+            time.sleep(Constant.USER_WAITING_TIME)
+        field.send_keys(string)
+
     def __upload(self) -> (bool, Optional[str]):
         self.browser.get(Constant.YOUTUBE_URL)
         time.sleep(Constant.USER_WAITING_TIME)
@@ -82,13 +92,7 @@ class YouTubeUploader:
         self.logger.debug('Attached thumbnail {}'.format(self.thumbnail_path))
 
         title_field = self.browser.find(By.ID, Constant.TEXTBOX, timeout=10)
-        title_field.click()
-        time.sleep(Constant.USER_WAITING_TIME)
-        title_field.clear()
-        time.sleep(Constant.USER_WAITING_TIME)
-        title_field.send_keys(Keys.COMMAND + 'a')
-        time.sleep(Constant.USER_WAITING_TIME)
-        title_field.send_keys(self.metadata_dict[Constant.VIDEO_TITLE])
+        self.__write_in_field(title_field, self.metadata_dict[Constant.VIDEO_TITLE], select_all=True)
         self.logger.debug('The video title was set to \"{}\"'.format(self.metadata_dict[Constant.VIDEO_TITLE]))
 
         video_description = self.metadata_dict[Constant.VIDEO_DESCRIPTION]
@@ -96,11 +100,7 @@ class YouTubeUploader:
             description_container = self.browser.find(By.XPATH,
                                                       Constant.DESCRIPTION_CONTAINER)
             description_field = self.browser.find(By.ID, Constant.TEXTBOX, element=description_container)
-            description_field.click()
-            time.sleep(Constant.USER_WAITING_TIME)
-            description_field.clear()
-            time.sleep(Constant.USER_WAITING_TIME)
-            description_field.send_keys(self.metadata_dict[Constant.VIDEO_DESCRIPTION])
+            self.__write_in_field(description_field, self.metadata_dict[Constant.VIDEO_DESCRIPTION])
             self.logger.debug(
                 'The video description was set to \"{}\"'.format(self.metadata_dict[Constant.VIDEO_DESCRIPTION]))
 

--- a/youtube_uploader_selenium/__init__.py
+++ b/youtube_uploader_selenium/__init__.py
@@ -24,8 +24,9 @@ class YouTubeUploader:
     """A class for uploading videos on YouTube via Selenium using metadata JSON file
     to extract its title, description etc"""
 
-    def __init__(self, video_path: str, metadata_json_path: Optional[str] = None) -> None:
+    def __init__(self, video_path: str, metadata_json_path: Optional[str] = None, thumbnail_path: Optional[str] = None) -> None:
         self.video_path = video_path
+        self.thumbnail_path = thumbnail_path
         self.metadata_dict = load_metadata(metadata_json_path)
         current_working_dir = str(Path.cwd())
         self.browser = Firefox(current_working_dir, current_working_dir)
@@ -73,6 +74,13 @@ class YouTubeUploader:
         absolute_video_path = str(Path.cwd() / self.video_path)
         self.browser.find(By.XPATH, Constant.INPUT_FILE_VIDEO).send_keys(absolute_video_path)
         self.logger.debug('Attached video {}'.format(self.video_path))
+
+        absolute_thumbnail_path = str(Path.cwd() / self.thumbnail_path)
+        self.browser.find(By.XPATH, Constant.INPUT_FILE_THUMBNAIL).send_keys(absolute_thumbnail_path)
+        change_display = "document.getElementById('file-loader').style = 'display: block! important'"
+        self.browser.driver.execute_script(change_display)
+        self.logger.debug('Attached thumbnail {}'.format(self.thumbnail_path))
+
         title_field = self.browser.find(By.ID, Constant.TEXTBOX, timeout=10)
         title_field.click()
         time.sleep(Constant.USER_WAITING_TIME)

--- a/youtube_uploader_selenium/__init__.py
+++ b/youtube_uploader_selenium/__init__.py
@@ -108,6 +108,17 @@ class YouTubeUploader:
         self.browser.find(By.ID, Constant.RADIO_LABEL, kids_section).click()
         self.logger.debug('Selected \"{}\"'.format(Constant.NOT_MADE_FOR_KIDS_LABEL))
 
+        # Advanced options
+        self.browser.find(By.XPATH, Constant.MORE_BUTTON).click()
+        self.logger.debug('Clicked MORE OPTIONS')
+
+        tags_container = self.browser.find(By.XPATH,
+                                                    Constant.TAGS_INPUT_CONTAINER)
+        tags_field = self.browser.find(By.ID, Constant.TAGS_INPUT, element=tags_container)
+        self.__write_in_field(tags_field, ','.join(self.metadata_dict[Constant.VIDEO_TAGS]))
+        self.logger.debug(
+            'The tags were set to \"{}\"'.format(self.metadata_dict[Constant.VIDEO_TAGS]))
+
         self.browser.find(By.ID, Constant.NEXT_BUTTON).click()
         self.logger.debug('Clicked {}'.format(Constant.NEXT_BUTTON))
 


### PR DESCRIPTION
I was not sure whether to put the thumbnail path in the metadata file or in the constructor/CLI, if you think the JSON file is better, I can change it.
I had problems with a few xpaths containing `paper-dialog`, so I updated them from my version of the DOM.